### PR TITLE
Easter Egg Fix

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -66,6 +66,10 @@ function App() {
     });
   };
 
+  const resetSelectedMembers = () => {
+    setSelectedMembers([]);
+  };
+  
   return (
     <div className="App">
       <h2 className="placeholder-app-name">Palminha do Twygo</h2>
@@ -73,8 +77,14 @@ function App() {
         {data.length > 0 && (
           <>
             <WheelComponent
-              data={data.filter((member) => !selectedMembers.includes(member.option))}
-              isEmpty={data.filter((member) => !selectedMembers.includes(member.option)).length === 0}
+              data={data.filter(
+                (member) => !selectedMembers.includes(member.option)
+              )}
+              isEmpty={
+                data.filter((member) => !selectedMembers.includes(member.option))
+                  .length === 0
+              }
+              onReset={resetSelectedMembers}
             />
           </>
         )}

--- a/src/components/SpinButton.js
+++ b/src/components/SpinButton.js
@@ -2,9 +2,17 @@ import React from 'react';
 import { MdWavingHand, MdOutlineStopCircle } from 'react-icons/md';
 import './SpinButton.css';
 
-const SpinButton = ({ onClick, easterEggTriggered }) => {
+const SpinButton = ({ onClick, easterEggTriggered, onReset }) => {
+  const handleClick = () => {
+    if (easterEggTriggered) {
+      onReset();
+    } else {
+      onClick();
+    }
+  };
+
   return (
-    <button onClick={onClick} className={easterEggTriggered ? 'easter-egg' : ''}>
+    <button onClick={handleClick} className={easterEggTriggered ? 'easter-egg' : ''}>
       {easterEggTriggered ? (
         <MdOutlineStopCircle className="hand-icon hand-icon-easter-egg" />
       ) : (

--- a/src/components/WheelComponent.js
+++ b/src/components/WheelComponent.js
@@ -6,7 +6,7 @@ import pointerImage from '../images/sophia.svg';
 import { generateGradientColors, getInverseColor } from '../helpers';
 import './WheelComponent.css';
 
-const WheelComponent = ({ data, isEmpty = false }) => {
+const WheelComponent = ({ data, isEmpty = false, onReset }) => {
   const [mustSpin, setMustSpin] = useState(false);
   const [prizeNumber, setPrizeNumber] = useState(0);
   const [modalIsOpen, setModalIsOpen] = useState(false);
@@ -51,8 +51,6 @@ const WheelComponent = ({ data, isEmpty = false }) => {
     },
   };
 
-
-
   return (
     <>
       {!isEmpty ? (
@@ -77,7 +75,7 @@ const WheelComponent = ({ data, isEmpty = false }) => {
           Hmmmmmmmmmmmm 🤔
         </div>
       )}
-      <SpinButton onClick={handleSpinClick} easterEggTriggered={easterEggTriggered} />
+      <SpinButton onClick={handleSpinClick} easterEggTriggered={easterEggTriggered} onReset={onReset} />
       <ResultModal isOpen={modalIsOpen} onRequestClose={closeModal} selectedNumber={data[prizeNumber]?.option} />
     </>
   );


### PR DESCRIPTION
## Problem
Currently, when the easter egg is triggered and the SpinButton is clicked, it doesn't reset the wheel and selected members list.

## Solution
This PR adds the reset functionality to the SpinButton. When the easter egg is triggered and the button is clicked, it resets the wheel and the selected members list. This is achieved by introducing an onReset callback in the SpinButton component and handling the reset logic in the App component.

## Changes
- Update SpinButton.js to handle the reset functionality when the easter egg is triggered.
- Add a new resetSelectedMembers function in the App component to reset the wheel and selected members list.
- Pass the resetSelectedMembers function as a prop to the SpinButton component.